### PR TITLE
Fix threshold flow, overlay and pair scoring

### DIFF
--- a/Milestone 2/evaluator.lua
+++ b/Milestone 2/evaluator.lua
@@ -59,7 +59,7 @@ function Eval.exact_category(cards)
   local counts = countsByRank(cards)
   if n == 2 then
     for _, cnt in pairs(counts) do
-      if cnt == 2 then return "One Pair" end
+      if cnt == 2 then return "Pair" end
     end
     return nil
   end

--- a/Milestone 2/gamestate.lua
+++ b/Milestone 2/gamestate.lua
@@ -1,7 +1,7 @@
 local Gamestate = {
   phase = "MAIN",
   turn  = 1,
-  playedHands = {},           -- e.g., { ["One Pair"]=true }
+    playedHands = {},           -- e.g., { ["Pair"]=true }
   limits = { joker_played_this_turn = false }, -- scaffold for 3.2
   meta   = { run_id = 1 }     -- placeholder; increments per restart if desired
 }

--- a/Milestone 2/main.lua
+++ b/Milestone 2/main.lua
@@ -81,6 +81,9 @@ local function setStatus(s) statusMsg = s or "" end
 
 local S = {}
 
+-- Forward declaration
+local nextTurn
+
 -- === SAFE HELPERS ===
 
 -- Auto-reshuffle: when deck is empty, move all discard back to deck and shuffle
@@ -260,7 +263,6 @@ local function tryWin()
 end
 
 -- === TURN HELPERS ===
-local nextTurn
 
 local function enterEndPhase()
   -- Resolve attack then auto-advance
@@ -899,7 +901,16 @@ function love.draw()
   end
 
   
-  -- Threshold/Win overlay
+  -- Hand
+  for i, c in ipairs(hand) do
+    drawCard(c, i)
+  end
+
+  if lastResult and lastResult.exact then
+          love.graphics.print("Last Played: "..lastResult.exact, 40, lastPlayedY)
+  end
+
+  -- Threshold/Win overlay (draw last so it appears above other elements)
   if UI and UI.overlay then
     local msg = UI.overlay.message or "Threshold completed"
     local ww, wh = love.graphics.getWidth(), love.graphics.getHeight()
@@ -917,14 +928,5 @@ function love.draw()
     BTN_NEXT_T.y = py + ph - 50
     drawButton(BTN_NEXT_T)
     love.graphics.setColor(1,1,1)
-  end
-
-  -- Hand
-  for i, c in ipairs(hand) do
-    drawCard(c, i)
-  end
-
-  if lastResult and lastResult.exact then
-          love.graphics.print("Last Played: "..lastResult.exact, 40, lastPlayedY)
   end
 end

--- a/Milestone 2/rules.lua
+++ b/Milestone 2/rules.lua
@@ -5,7 +5,7 @@ local Rules = {}
 -- Categories used by the "played-once" board
 Rules.CATEGORIES = {
   "High Card",
-  "One Pair",
+  "Pair",
   "Two Pair",
   "Three of a Kind",
   "Straight",

--- a/Milestone 2/scoring.lua
+++ b/Milestone 2/scoring.lua
@@ -19,11 +19,10 @@ local function clamp_threshold(t) return math.max(1, math.floor(t or 1)) end
 
 function M.init(S)
   S.meta = S.meta or {}
-  if S.meta.threshold == nil then S.meta.threshold = 1
+  if S.meta.threshold == nil then S.meta.threshold = 1 end
   S.meta.turns = S.meta.turns or 0
   S.meta.pressure_level = S.meta.pressure_level or 0
   S.meta.turns_since_pressure = S.meta.turns_since_pressure or 0
-end
   if S.meta.score == nil then S.meta.score = 0 end
   if S.meta.punish_level == nil then S.meta.punish_level = 0 end -- +1 every 30 moves (hook later)
 end
@@ -101,23 +100,22 @@ function M.reset_for_next_threshold(S)
   S.meta.score = 0
 end
 
-return M
-
-
--- === Pressure Meter (every 30 turns) ===
-function M.on_turn_advanced(S)
-  if not S or not S.meta then return end
-  S.meta.turns = (S.meta.turns or 0) + 1
-  S.meta.turns_since_pressure = (S.meta.turns_since_pressure or 0) + 1
-  while S.meta.turns_since_pressure >= 30 do
-    S.meta.turns_since_pressure = S.meta.turns_since_pressure - 30
-    S.meta.pressure_level = (S.meta.pressure_level or 0) + 1
+  -- === Pressure Meter (every 30 turns) ===
+  function M.on_turn_advanced(S)
+    if not S or not S.meta then return end
+    S.meta.turns = (S.meta.turns or 0) + 1
+    S.meta.turns_since_pressure = (S.meta.turns_since_pressure or 0) + 1
+    while S.meta.turns_since_pressure >= 30 do
+      S.meta.turns_since_pressure = S.meta.turns_since_pressure - 30
+      S.meta.pressure_level = (S.meta.pressure_level or 0) + 1
+    end
   end
-end
 
-function M.pressure_next_in(S)
-  if not S or not S.meta then return 30 end
-  local r = 30 - (S.meta.turns_since_pressure or 0)
-  if r <= 0 then r = 30 end
-  return r
-end
+  function M.pressure_next_in(S)
+    if not S or not S.meta then return 30 end
+    local r = 30 - (S.meta.turns_since_pressure or 0)
+    if r <= 0 then r = 30 end
+    return r
+  end
+
+  return M


### PR DESCRIPTION
## Summary
- Prevent nil `nextTurn` by forward declaring and reusing it in threshold advancement
- Standardize "Pair" category and evaluator output for proper attack protection
- Move pressure meter functions into Scoring module and layer win/threshold overlay above cards

## Testing
- `luac -p main.lua scoring.lua evaluator.lua rules.lua gamestate.lua attacks.lua` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68be409f1f348322b617f61717e1a5ce